### PR TITLE
Add a .gitignore, which blacklists build results (.o, .gch (generated…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+# Build results
+*.o
+*.gch
+*.a


### PR DESCRIPTION
… header files) and .a (the resulting archive))

Ideally the existing .gch file would be removed from this repository as well, because it will be built by gcc.
When doing that, one could also could be more specific and blacklist .h.gch