### PR TITLE
remove bcm_host dependency + Makefile constants CC/CXX overwritable from command line

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -3,6 +3,7 @@ CXXFLAGS ?= -std=c++11 -Wall -O3 -Wno-unused-variable -I /opt/vc/include
 LDFLAGS ?= -lm -lrt -lpthread -L/opt/vc/lib -lbcm_host
 CXX ?= c++
 CC ?= cc
+PREFIX ?= /usr/local/
 
 librpitx: librpitx.h gpio.h gpio.cpp dma.h dma.cpp mailbox.c raspberry_pi_revision.c fmdmasync.h fmdmasync.cpp ngfmdmasync.h ngfmdmasync.cpp dsp.h dsp.cpp iqdmasync.h iqdmasync.cpp serialdmasync.h serialdmasync.cpp phasedmasync.h phasedmasync.cpp fskburst.h fskburst.cpp ookburst.cpp ookburst.h atv.h atv.cpp util.h
 	$(CC) $(CFLAGS) -c -o raspberry_pi_revision.o raspberry_pi_revision.c
@@ -10,6 +11,10 @@ librpitx: librpitx.h gpio.h gpio.cpp dma.h dma.cpp mailbox.c raspberry_pi_revisi
 	$(AR) rc librpitx.a rpi.o dsp.o iqdmasync.o ngfmdmasync.o fmdmasync.o  dma.o gpio.o mailbox.o raspberry_pi_revision.o  serialdmasync.o phasedmasync.o amdmasync.o fskburst.o ookburst.o atv.o util.o mailbox.o
 
 install: librpitx
+	mkdir -p $(PREFIX)/include/librpitx
+	install *.h $(PREFIX)/include/librpitx
+	mkdir -p $(PREFIX)/lib
+	install librpitx.a $(PREFIX)/lib
 
 clean:
 	rm -f *.o *.a

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,14 +1,13 @@
-CFLAGS = -Wall -O3 -Wno-unused-variable
-CXXFLAGS = -std=c++11 -Wall -O3 -Wno-unused-variable -I /opt/vc/include 
-LDFLAGS = -lm -lrt -lpthread -L/opt/vc/lib -lbcm_host
-CCP = c++
-CC = cc
+CFLAGS ?= -Wall -O3 -Wno-unused-variable
+CXXFLAGS ?= -std=c++11 -Wall -O3 -Wno-unused-variable -I /opt/vc/include
+LDFLAGS ?= -lm -lrt -lpthread -L/opt/vc/lib -lbcm_host
+CXX ?= c++
+CC ?= cc
 
 librpitx: librpitx.h gpio.h gpio.cpp dma.h dma.cpp mailbox.c raspberry_pi_revision.c fmdmasync.h fmdmasync.cpp ngfmdmasync.h ngfmdmasync.cpp dsp.h dsp.cpp iqdmasync.h iqdmasync.cpp serialdmasync.h serialdmasync.cpp phasedmasync.h phasedmasync.cpp fskburst.h fskburst.cpp ookburst.cpp ookburst.h atv.h atv.cpp util.h
-	#$(CC) $(CFLAGS) -c -o mailbox.o mailbox.c
 	$(CC) $(CFLAGS) -c -o raspberry_pi_revision.o raspberry_pi_revision.c
-	$(CCP) $(CXXFLAGS) -c dsp.cpp iqdmasync.cpp ngfmdmasync.cpp fmdmasync.cpp  dma.cpp gpio.cpp serialdmasync.cpp phasedmasync.cpp amdmasync.h amdmasync.cpp fskburst.cpp ookburst.cpp atv.cpp util.cpp mailbox.c
-	$(AR) rc librpitx.a dsp.o iqdmasync.o ngfmdmasync.o fmdmasync.o  dma.o gpio.o mailbox.o raspberry_pi_revision.o  serialdmasync.o phasedmasync.o amdmasync.o fskburst.o ookburst.o atv.o util.o mailbox.o
+	$(CXX) $(CXXFLAGS) -c rpi.c dsp.cpp iqdmasync.cpp ngfmdmasync.cpp fmdmasync.cpp  dma.cpp gpio.cpp serialdmasync.cpp phasedmasync.cpp amdmasync.h amdmasync.cpp fskburst.cpp ookburst.cpp atv.cpp util.cpp mailbox.c
+	$(AR) rc librpitx.a rpi.o dsp.o iqdmasync.o ngfmdmasync.o fmdmasync.o  dma.o gpio.o mailbox.o raspberry_pi_revision.o  serialdmasync.o phasedmasync.o amdmasync.o fskburst.o ookburst.o atv.o util.o mailbox.o
 
 install: librpitx
 

--- a/src/dma.cpp
+++ b/src/dma.cpp
@@ -19,7 +19,7 @@ This program is free software: you can redistribute it and/or modify
 #include "dma.h"
 #include "stdio.h"
 #include "util.h"
-#include <bcm_host.h>
+#include "rpi.h"
 
 extern "C"
 {

--- a/src/gpio.cpp
+++ b/src/gpio.cpp
@@ -24,9 +24,9 @@ extern "C" {
 #include <unistd.h>
 #include <sys/timex.h>
 #include <math.h>
+#include <string.h>
 #include "util.h"
-#include <bcm_host.h>
-//#include "/opt/vc/include/bcm_host.h"
+#include "rpi.h"
 
 gpio::gpio(uint32_t base, uint32_t len)
 {
@@ -94,15 +94,16 @@ uint32_t gpio::GetPeripheralBase()
 {
 	RASPBERRY_PI_INFO_T info;
 	uint32_t BCM2708_PERI_BASE =bcm_host_get_peripheral_address();
-	dbg_printf(1,"Peri Base = %x SDRAM %x\n",/*get_hwbase()*/bcm_host_get_peripheral_address(),bcm_host_get_sdram_address());
+	dbg_printf(0,"Peri Base = %x SDRAM %x\n",/*get_hwbase()*/bcm_host_get_peripheral_address(),bcm_host_get_sdram_address());
 	if(BCM2708_PERI_BASE==0xFE000000) // Fixme , could be inspect without this hardcoded value
 	{
+               dbg_printf(0,"RPi4 GPIO detected\n");
 		pi_is_2711=true;  //Rpi4
 		XOSC_FREQUENCY=54000000;
 	}
 	if(BCM2708_PERI_BASE==0)
 	{
-		dbg_printf(0,"Unknown peripheral base, swith to PI4 \n");
+		dbg_printf(0,"Unknown peripheral base, switch to PI4 \n");
 		BCM2708_PERI_BASE=0xfe000000;
 		XOSC_FREQUENCY=54000000;
 		pi_is_2711=true;  

--- a/src/rpi.c
+++ b/src/rpi.c
@@ -1,0 +1,31 @@
+#include "stdint.h"
+#include <cstdio>
+
+static unsigned get_dt_ranges(const char *filename, unsigned offset)
+{
+   unsigned address = ~0;
+   FILE *fp = fopen(filename, "rb");
+   if (fp)
+   {
+      unsigned char buf[4];
+      fseek(fp, offset, SEEK_SET);
+      if (fread(buf, 1, sizeof buf, fp) == sizeof buf)
+         address = buf[0] << 24 | buf[1] << 16 | buf[2] << 8 | buf[3] << 0;
+      fclose(fp);
+   }
+   return address;
+}
+
+unsigned bcm_host_get_peripheral_address(void)
+{
+   unsigned address = get_dt_ranges("/proc/device-tree/soc/ranges", 4);
+   if (address == 0)
+      address = get_dt_ranges("/proc/device-tree/soc/ranges", 8);
+   return address == ~0 ? 0x20000000 : address;
+}
+
+unsigned bcm_host_get_sdram_address(void)
+{
+    unsigned address = get_dt_ranges("/proc/device-tree/axi/vc_mem/reg", 8);
+    return address == ~0 ? 0x40000000 : address;
+}

--- a/src/rpi.h
+++ b/src/rpi.h
@@ -1,0 +1,3 @@
+static unsigned get_dt_ranges(const char *filename, unsigned offset);
+unsigned bcm_host_get_peripheral_address(void);
+unsigned bcm_host_get_sdram_address(void);


### PR DESCRIPTION
For cross compiling from Buildroot: 
* remove dependency to bcm_host (not supported for 64-bit architecture) by including relevant functions in the souce code 
* get compiler name from command line by replacing affectation (=) with ?= for cross-compiling